### PR TITLE
♻️ Removing unnecessary struct and renaming unexported constants

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -31,10 +31,10 @@ const (
 type slotStatus uint8
 
 const (
-	slotStatusEmpty       slotStatus = iota // The slot is empty.
-	slotStatusExternal                      // The slot contains an external task
-	slotStatusUnprotected                   // The slot is unprotected meaning its task may be cancelled at any time.
-	slotStatusProtected                     // The slot is protected meaning its task will be be done.
+	slotStatusEmpty               slotStatus = iota // The slot is empty.
+	slotStatusUnprotectedExternal                   // The slot contains an unprotected external task
+	slotStatusUnprotectedInternal                   // The slot contains an unprotected internal task
+	slotStatusProtected                             // The slot contains a protected task which must be done (i.e. only killed during shutdown).
 	numSlotStatuses
 )
 
@@ -42,9 +42,9 @@ func (s slotStatus) export() SlotStatus {
 	switch s {
 	case slotStatusEmpty:
 		return SlotStatusEmpty
-	case slotStatusExternal:
+	case slotStatusUnprotectedExternal:
 		return SlotStatusUnprotectedExternal
-	case slotStatusUnprotected:
+	case slotStatusUnprotectedInternal:
 		return SlotStatusUnprotectedInternal
 	case slotStatusProtected:
 		return SlotStatusProtected

--- a/server.go
+++ b/server.go
@@ -336,7 +336,7 @@ func (server *Server) expand() {
 // expandExternal runs tasks that were added externally i.e. via the control
 // message handler.
 func (server *Server) expandExternal() {
-	available := server.findSuitableSlotCount(slotStatusExternal)
+	available := server.findSuitableSlotCount(slotStatusUnprotectedExternal)
 	if len(server.externalTasks) == 0 || available <= 0 {
 		return
 	}
@@ -350,7 +350,7 @@ func (server *Server) expandExternal() {
 			continue
 		}
 
-		ok := server.addAndDoTask(task.task, slotStatusExternal, nil)
+		ok := server.addAndDoTask(task.task, slotStatusUnprotectedExternal, nil)
 		if !ok {
 			return
 		}
@@ -379,9 +379,9 @@ func (server *Server) expandLocal() {
 	for _, index := range indices {
 		slot := server.slots[index]
 
-		status := slotStatusUnprotected
-		if slot.slotStatus == slotStatusExternal {
-			status = slotStatusExternal
+		status := slotStatusUnprotectedInternal
+		if slot.slotStatus == slotStatusUnprotectedExternal {
+			status = slotStatusUnprotectedExternal
 		}
 
 		available := server.findSuitableSlotCount(status)

--- a/server.go
+++ b/server.go
@@ -136,11 +136,7 @@ func (server *Server) HandleRequestMsg(msg Message) {
 		return
 	}
 
-	properties := properties{
-		state: slotStatusProtected,
-	}
-
-	if !server.addAndDoTask(task, properties, msg) {
+	if !server.addAndDoTask(task, slotStatusProtected, msg) {
 		server.msgReject(msg, true)
 		details := task.Details()
 		err := NewDetailedError(ErrTaskNotAdded, fmt.Sprintf("unable to add task with id %s", details.ID))
@@ -191,11 +187,11 @@ func (server *Server) Shutdown(ctx context.Context) {
 // addAndDoTask attempts to add a task into a suitable
 // slot. A boolean is indicating if the task was
 // successfully added.
-func (server *Server) addAndDoTask(task Task, properties properties, msg Message) bool {
+func (server *Server) addAndDoTask(task Task, status slotStatus, msg Message) bool {
 	server.slotsMutex.Lock()
 	defer server.slotsMutex.Unlock()
 
-	index, ok := server.findSuitableSlotIndex(properties.state)
+	index, ok := server.findSuitableSlotIndex(status)
 	if !ok {
 		return false
 	}
@@ -212,11 +208,11 @@ func (server *Server) addAndDoTask(task Task, properties properties, msg Message
 	}
 
 	// Sets task in given slot
-	server.slots[index].setTask(task, properties.state)
+	server.slots[index].setTask(task, status)
 
 	slot := server.slots[index]
 	taskName := slot.getTaskGroup()
-	server.adjustResourcesTaskStarting(properties.state, taskName)
+	server.adjustResourcesTaskStarting(status, taskName)
 	go func() {
 		startTime := time.Now()
 
@@ -229,15 +225,15 @@ func (server *Server) addAndDoTask(task Task, properties properties, msg Message
 		//    should be be requeued UNLESS the task completed without any error.
 		case err == ErrTaskInterrupted:
 			defer server.msgReject(msg, true)
-		case err != nil && properties.state == slotStatusProtected:
+		case err != nil && status == slotStatusProtected:
 			defer server.msgReject(msg, false)
 			server.config.Monitors.Error.RecordError(err)
 		default:
 			defer server.msgAck(msg)
 		}
 
-		server.recordTaskDuration(startTime, properties.state, taskName)
-		server.adjustResourcesTaskStopping(properties.state, taskName)
+		server.recordTaskDuration(startTime, status, taskName)
+		server.adjustResourcesTaskStopping(status, taskName)
 
 		slot.empty()
 	}()
@@ -246,15 +242,10 @@ func (server *Server) addAndDoTask(task Task, properties properties, msg Message
 }
 
 func (server *Server) addToExternalTasks(task Task) {
-	properties := properties{
-		state: slotStatusExternal,
-	}
-
 	server.externalTasksMutex.Lock()
 	server.externalTasks = append(server.externalTasks, &externalTask{
-		task:       task,
-		details:    task.Details(),
-		properties: properties,
+		task:    task,
+		details: task.Details(),
 	})
 	server.externalTasksMutex.Unlock()
 }
@@ -359,7 +350,7 @@ func (server *Server) expandExternal() {
 			continue
 		}
 
-		ok := server.addAndDoTask(task.task, task.properties, nil)
+		ok := server.addAndDoTask(task.task, slotStatusExternal, nil)
 		if !ok {
 			return
 		}
@@ -388,21 +379,19 @@ func (server *Server) expandLocal() {
 	for _, index := range indices {
 		slot := server.slots[index]
 
-		properties := properties{
-			state: slotStatusUnprotected,
-		}
+		status := slotStatusUnprotected
 		if slot.slotStatus == slotStatusExternal {
-			properties.state = slotStatusExternal
+			status = slotStatusExternal
 		}
 
-		available := server.findSuitableSlotCount(properties.state)
+		available := server.findSuitableSlotCount(status)
 		if available == 0 {
 			return
 		}
 
 		tasks := slot.expand(available)
 		for _, task := range tasks {
-			ok := server.addAndDoTask(task, properties, nil)
+			ok := server.addAndDoTask(task, status, nil)
 			if !ok {
 				return
 			}

--- a/server.go
+++ b/server.go
@@ -212,7 +212,7 @@ func (server *Server) addAndDoTask(task Task, properties properties, msg Message
 	}
 
 	// Sets task in given slot
-	server.slots[index].setTask(task, properties)
+	server.slots[index].setTask(task, properties.state)
 
 	slot := server.slots[index]
 	taskName := slot.getTaskGroup()
@@ -381,7 +381,7 @@ func (server *Server) expandLocal() {
 	// Sorts indices to prioritise by slotStatus
 	indices := rand.Perm(server.config.Slots)
 	sort.Slice(indices, func(i, j int) bool {
-		return server.slots[i].properties.state > server.slots[j].properties.state
+		return server.slots[i].slotStatus > server.slots[j].slotStatus
 	})
 
 	// Attempts to expand tasks (in the order in which they prioritised)
@@ -391,7 +391,7 @@ func (server *Server) expandLocal() {
 		properties := properties{
 			state: slotStatusUnprotected,
 		}
-		if slot.properties.state == slotStatusExternal {
+		if slot.slotStatus == slotStatusExternal {
 			properties.state = slotStatusExternal
 		}
 

--- a/slot.go
+++ b/slot.go
@@ -25,7 +25,7 @@ type externalTask struct {
 type slot struct {
 	task       Task        // The task assigned to the slot
 	details    TaskDetails // The details of the task assigned to the slot set by the handler/task
-	properties properties  // The properties of the task and slot set by occamy
+	slotStatus slotStatus
 
 	mutex    sync.Mutex // Lock to prevent clashes when accessing/modifying data.
 	occupied *semaphore // occupied is activated when a task is set and deactivated when the slot is emptied.
@@ -35,11 +35,9 @@ type slot struct {
 // newSlot creates a new empty slot.
 func newSlot() *slot {
 	slot := &slot{
-		properties: properties{
-			state: slotStatusEmpty,
-		},
-		occupied: newSemaphore(false),
-		usable:   newSemaphore(false),
+		slotStatus: slotStatusEmpty,
+		occupied:   newSemaphore(false),
+		usable:     newSemaphore(false),
 	}
 
 	return slot
@@ -66,8 +64,7 @@ func (s *slot) empty() {
 	if s.occupied.isActive() {
 		s.task = nil
 		s.details = TaskDetails{}
-		s.properties = properties{}
-		s.properties.state = slotStatusEmpty
+		s.slotStatus = slotStatusEmpty
 		s.usable.deactivate()
 		s.occupied.deactivate()
 	}
@@ -133,7 +130,7 @@ func (s *slot) handleControlMsg(headers Headers, body []byte) error {
 // isEmpty returns if the slotStatus of the task is empty.
 func (s *slot) isEmpty() bool {
 	s.mutex.Lock()
-	result := s.properties.state == slotStatusEmpty
+	result := s.slotStatus == slotStatusEmpty
 	s.mutex.Unlock()
 	return result
 }
@@ -142,7 +139,7 @@ func (s *slot) isEmpty() bool {
 // nolint
 func (s *slot) isProtected() bool {
 	s.mutex.Lock()
-	result := s.properties.state == slotStatusProtected
+	result := s.slotStatus == slotStatusProtected
 	s.mutex.Unlock()
 	return result
 }
@@ -171,7 +168,7 @@ func (s *slot) newContext() (context.Context, func()) {
 
 // setTask sets the task along with the other relevant information.
 // This must only ever be done on an empty task.
-func (s *slot) setTask(task Task, properties properties) {
+func (s *slot) setTask(task Task, status slotStatus) {
 	if task == nil {
 		return
 	}
@@ -179,7 +176,7 @@ func (s *slot) setTask(task Task, properties properties) {
 	s.mutex.Lock()
 	s.task = task
 	s.details = task.Details()
-	s.properties = properties
+	s.slotStatus = status
 
 	s.occupied.activate()
 	s.usable.activate()
@@ -188,9 +185,9 @@ func (s *slot) setTask(task Task, properties properties) {
 
 func (s *slot) state() slotStatus {
 	s.mutex.Lock()
-	state := s.properties.state
+	status := s.slotStatus
 	s.mutex.Unlock()
-	return state
+	return status
 }
 
 // waitTillEmpty waits until the slot is empty or until the timeout is reached.

--- a/slot.go
+++ b/slot.go
@@ -6,18 +6,12 @@ import (
 	"time"
 )
 
-// properties represent the properties of the slot and task
-type properties struct {
-	state slotStatus // The state of the slot i.e. empty, protected or unprotected.
-}
-
 // externalTask represents a request message that was handled via the control
 // handler. It is to be kept by the server and added if there is space in the
 // expansion process.
 type externalTask struct {
-	task       Task        // The task
-	details    TaskDetails // The task's details
-	properties properties  // The task's properties
+	task    Task        // The task
+	details TaskDetails // The task's details
 }
 
 // slot represents a slot for a task in the server.


### PR DESCRIPTION
- The struct `properties` was removed.
- The constants for `slotStatus` where renamed to match their exported counterparts.