### PR TITLE
✨ Exporting server expansion method

### DIFF
--- a/server.go
+++ b/server.go
@@ -63,9 +63,15 @@ func NewServer(config ServerConfig) *Server {
 	server.close = make(chan struct{})
 	server.once = &sync.Once{}
 
-	go startPeriodicProcess(server.expand, config.ExpansionPeriod, server.close)
+	go startPeriodicProcess(server.Expand, config.ExpansionPeriod, server.close)
 
 	return server
+}
+
+// Expand runs the expansion processes.
+func (server *Server) Expand() {
+	server.expandLocal()
+	server.expandExternal()
 }
 
 // HandleControlMsg handles a control method.
@@ -334,12 +340,6 @@ func (server *Server) findSuitableSlotCount(state slotStatus) int {
 	}
 
 	return count
-}
-
-// expand runs the expansion processes.
-func (server *Server) expand() {
-	server.expandLocal()
-	server.expandExternal()
 }
 
 // expandExternal runs tasks that were added externally i.e. via the control

--- a/server.go
+++ b/server.go
@@ -63,13 +63,17 @@ func NewServer(config ServerConfig) *Server {
 	server.close = make(chan struct{})
 	server.once = &sync.Once{}
 
-	go startPeriodicProcess(server.Expand, config.ExpansionPeriod, server.close)
+	go startPeriodicProcess(server.ExpandTasks, config.ExpansionPeriod, server.close)
 
 	return server
 }
 
-// Expand runs the expansion processes.
-func (server *Server) Expand() {
+// ExpandTasks calls expand on running tasks and runs externally added tasks
+// provided there is sufficient space.
+//
+// It is generally recommended have the server using a periodic expansion. This
+// method has been included so that custom expansion schedules can be performed.
+func (server *Server) ExpandTasks() {
 	server.expandInternal()
 	server.expandExternal()
 }

--- a/server.go
+++ b/server.go
@@ -70,7 +70,7 @@ func NewServer(config ServerConfig) *Server {
 
 // Expand runs the expansion processes.
 func (server *Server) Expand() {
-	server.expandLocal()
+	server.expandInternal()
 	server.expandExternal()
 }
 
@@ -370,8 +370,8 @@ func (server *Server) expandExternal() {
 	server.externalTasksMutex.Unlock()
 }
 
-// expandLocal expands the tasks already running on the server.
-func (server *Server) expandLocal() {
+// expandInternal expands the tasks already running on the server.
+func (server *Server) expandInternal() {
 	if server.resourceCounts[slotStatusEmpty].isEqual(server.config.Slots) || server.findSuitableSlotCount(slotStatusProtected-1) == 0 {
 		return
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -28,21 +28,21 @@ const (
 	ShortDuration = 10 * time.Millisecond
 )
 
-// TestServer_Expand tests that the expand method can be called without error.
-func TestServer_Expand(t *testing.T) {
+// TestServer_ExpandTasks tests that the expand method can be called without error.
+func TestServer_ExpandTasks(t *testing.T) {
 	server, monitors := NewServer(nil)
 
-	server.Expand()
+	server.ExpandTasks()
 	assertErrorIsNil(t, monitors.Error.nextError(), "error after expand")
 	assertResourceMonitorStatusMatch(t, monitors.Resource, DefaultResources, 0, 0, 0, "resources after expand")
 
 	testServerShutdownSuccess(t, server, monitors, DefaultResources)
 }
 
-// TestServer_Expand_expandableExternalTask tests that calling Expand while
+// TestServer_ExpandTasks_expandableExternalTask tests that calling ExpandTasks while
 // there is an "external" task will be added to a slot and after a second call
-// of Expand will use all available resources.
-func TestServer_Expand_expandableExternalTask(t *testing.T) {
+// of ExpandTasks will use all available resources.
+func TestServer_ExpandTasks_expandableExternalTask(t *testing.T) {
 	controller := NewTaskController()
 	handler := NewStandardHandler(controller)
 	server, monitors := NewServer(handler.Handle)
@@ -53,20 +53,20 @@ func TestServer_Expand_expandableExternalTask(t *testing.T) {
 	assertResourceMonitorStatusMatch(t, monitors.Resource, DefaultResources, 0, 0, 0, "resources after request message in control handler")
 
 	time.Sleep(ShortDuration)
-	server.Expand()
+	server.ExpandTasks()
 	assertErrorIsNil(t, monitors.Error.nextError(), "error after expand")
 	assertResourceMonitorStatusMatch(t, monitors.Resource, DefaultResources-1, 0, 0, 1, "resources after expand")
 
-	server.Expand()
+	server.ExpandTasks()
 	assertErrorIsNil(t, monitors.Error.nextError(), "error after second expand")
 	assertResourceMonitorStatusMatch(t, monitors.Resource, 0, 0, 0, DefaultResources, "resources after second expand")
 
 	testServerShutdownSuccess(t, server, monitors, DefaultResources)
 }
 
-// TestServer_Expand_expandableExternalTask tests that calling Expand while
+// TestServer_Expand_expandableExternalTask tests that calling ExpandTasks while
 // there is a protected expandable task will use all available resources.
-func TestServer_Expand_expandableProtectedTask(t *testing.T) {
+func TestServer_ExpandTasks_expandableProtectedTask(t *testing.T) {
 	controller := NewTaskController()
 	handler := NewStandardHandler(controller)
 	server, monitors := NewServer(handler.Handle)
@@ -75,16 +75,16 @@ func TestServer_Expand_expandableProtectedTask(t *testing.T) {
 	msg := mf.NewSimpleTaskMessage(true)
 	testHandleRequestMessageSuccess(t, server, monitors, msg, "")
 
-	server.Expand()
+	server.ExpandTasks()
 	assertErrorIsNil(t, monitors.Error.nextError(), "error after expand")
 	assertResourceMonitorStatusMatch(t, monitors.Resource, 0, 1, DefaultResources-1, 0, "resources after expand")
 
 	testServerShutdownSuccess(t, server, monitors, DefaultResources)
 }
 
-// TestServer_Expand_expansionBuffer tests that the Expand method will respect
+// TestServer_ExpandTasks_expansionBuffer tests that the ExpandTasks method will respect
 // the expansion buffer.
-func TestServer_Expand_expansionBuffer(t *testing.T) {
+func TestServer_ExpandTasks_expansionBuffer(t *testing.T) {
 	controller := NewTaskController()
 	handler := NewStandardHandler(controller)
 	monitors := NewMonitors(DefaultResources)
@@ -106,16 +106,16 @@ func TestServer_Expand_expansionBuffer(t *testing.T) {
 	msg := mf.NewSimpleTaskMessage(true)
 	testHandleRequestMessageSuccess(t, server, monitors, msg, "")
 
-	server.Expand()
+	server.ExpandTasks()
 	assertErrorIsNil(t, monitors.Error.nextError(), "error after expand")
 	assertResourceMonitorStatusMatch(t, monitors.Resource, 2, 1, DefaultResources-3, 0, "resources after expand")
 
 	testServerShutdownSuccess(t, server, monitors, DefaultResources)
 }
 
-// TestServer_Expand_unexpandableProtectedTask tests that Expand will do nothing
+// TestServer_ExpandTasks_unexpandableProtectedTask tests that ExpandTasks will do nothing
 // when there is a task that can not be expanded.
-func TestServer_Expand_unexpandableProtectedTask(t *testing.T) {
+func TestServer_ExpandTasks_unexpandableProtectedTask(t *testing.T) {
 	controller := NewTaskController()
 	handler := NewStandardHandler(controller)
 	server, monitors := NewServer(handler.Handle)
@@ -124,7 +124,7 @@ func TestServer_Expand_unexpandableProtectedTask(t *testing.T) {
 	msg := mf.NewSimpleTaskMessage(false)
 	testHandleRequestMessageSuccess(t, server, monitors, msg, "")
 
-	server.Expand()
+	server.ExpandTasks()
 	assertErrorIsNil(t, monitors.Error.nextError(), "error after expand")
 	assertResourceMonitorStatusMatch(t, monitors.Resource, DefaultResources-1, 1, 0, 0, "resources after expand")
 
@@ -382,8 +382,8 @@ func TestServer_HandleRequestMsg_postExpansionExternal(t *testing.T) {
 	server.HandleControlMsg(msgA)
 	time.Sleep(ShortDuration)
 
-	server.Expand()
-	server.Expand()
+	server.ExpandTasks()
+	server.ExpandTasks()
 	assertResourceMonitorStatusMatch(t, monitors.Resource, 0, 0, 0, DefaultResources, "resources after expansion")
 
 	msgB := mf.NewSimpleTaskMessage(true)
@@ -404,7 +404,7 @@ func TestServer_HandleRequestMsg_postExpansionInternal(t *testing.T) {
 	msgA := mf.NewSimpleTaskMessage(true)
 	testHandleRequestMessageSuccess(t, server, monitors, msgA, "handling single message")
 
-	server.Expand()
+	server.ExpandTasks()
 	assertResourceMonitorStatusMatch(t, monitors.Resource, 0, 1, DefaultResources-1, 0, "resources after expand")
 
 	msgB := mf.NewSimpleTaskMessage(true)
@@ -439,7 +439,7 @@ func TestServer_HandleRequestMsg_postExpansionWithExpansionBuffer(t *testing.T) 
 	msgA := mf.NewSimpleTaskMessage(true)
 	testHandleRequestMessageSuccess(t, server, monitors, msgA, "handling single message")
 
-	server.Expand()
+	server.ExpandTasks()
 	assertResourceMonitorStatusMatch(t, monitors.Resource, 2, 1, DefaultResources-3, 0, "resources after expansion")
 
 	msgB := mf.NewSimpleTaskMessage(true)


### PR DESCRIPTION
Exporting the server expansion method allows for users to manually control when expansion occurs.